### PR TITLE
Adding Wire-Cell PMT Info

### DIFF
--- a/ubobj/WcpPort/NuSelectionBDT.cxx
+++ b/ubobj/WcpPort/NuSelectionBDT.cxx
@@ -48,6 +48,8 @@ using namespace nsm;
 	  NuSelectionBDT::NumuCCTagger _NumuCCTagger_init = {0};
 	  NuSelectionBDT::BDTscores _BDTscores_init = {0};
 
+	  NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {0};
+
     _stkdar_ = _stkdar_init;
 
     _SPID_ = _SPID_init;
@@ -90,6 +92,8 @@ using namespace nsm;
 	  _MajorCosmicTagger_ = _MajorCosmicTagger_init;
 	  _NumuCCTagger_ = _NumuCCTagger_init;
 	  _BDTscores_ = _BDTscores_init;
+
+	_WCPMTInfo_ = _WCPMTInfo_init;
   }
 
   void NuSelectionBDT::reset(){
@@ -137,6 +141,8 @@ using namespace nsm;
 	  NuSelectionBDT::NumuCCTagger _NumuCCTagger_init = {0};
 	  NuSelectionBDT::BDTscores _BDTscores_init = {0};
 
+	  NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {0};
+
     _stkdar_ = _stkdar_init;
 
     _SPID_ = _SPID_init;
@@ -179,6 +185,8 @@ using namespace nsm;
 	  _MajorCosmicTagger_ = _MajorCosmicTagger_init;
 	  _NumuCCTagger_ = _NumuCCTagger_init;
 	  _BDTscores_ = _BDTscores_init;
+
+	  _WCPMTInfo_ = _WCPMTInfo_init;
   }
 
   void NuSelectionBDT::Setstkdar(NuSelectionBDT::stkdar BDT_input){ this->_stkdar_=BDT_input; }
@@ -224,6 +232,8 @@ using namespace nsm;
   void NuSelectionBDT::SetNumuCCTagger(NuSelectionBDT::NumuCCTagger BDT_input){ this->_NumuCCTagger_=BDT_input; }
   void NuSelectionBDT::SetBDTscores(NuSelectionBDT::BDTscores BDT_input){ this->_BDTscores_=BDT_input; }
 
+  void NuSelectionBDT::SetWCPMTInfo(NuSelectionBDT::WCPMTInfo BDT_input){ this->_WCPMTInfo_=BDT_input; }
+
   const NuSelectionBDT::stkdar & NuSelectionBDT::Getstkdar() const { return this->_stkdar_; }
 
   const NuSelectionBDT::SPID & NuSelectionBDT::GetSPID() const { return this->_SPID_; }
@@ -266,3 +276,5 @@ using namespace nsm;
   const NuSelectionBDT::MajorCosmicTagger & NuSelectionBDT::GetMajorCosmicTagger() const { return this->_MajorCosmicTagger_; }
   const NuSelectionBDT::NumuCCTagger & NuSelectionBDT::GetNumuCCTagger() const { return this->_NumuCCTagger_; }
   const NuSelectionBDT::BDTscores & NuSelectionBDT::GetBDTscores() const { return this->_BDTscores_; }
+
+  const NuSelectionBDT::WCPMTInfo & NuSelectionBDT::GetWCPMTInfo() const { return this->_WCPMTInfo_; }

--- a/ubobj/WcpPort/NuSelectionBDT.cxx
+++ b/ubobj/WcpPort/NuSelectionBDT.cxx
@@ -48,8 +48,6 @@ using namespace nsm;
 	  NuSelectionBDT::NumuCCTagger _NumuCCTagger_init = {0};
 	  NuSelectionBDT::BDTscores _BDTscores_init = {0};
 
-	  NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {0};
-
     _stkdar_ = _stkdar_init;
 
     _SPID_ = _SPID_init;
@@ -92,8 +90,6 @@ using namespace nsm;
 	  _MajorCosmicTagger_ = _MajorCosmicTagger_init;
 	  _NumuCCTagger_ = _NumuCCTagger_init;
 	  _BDTscores_ = _BDTscores_init;
-
-	_WCPMTInfo_ = _WCPMTInfo_init;
   }
 
   void NuSelectionBDT::reset(){
@@ -141,8 +137,6 @@ using namespace nsm;
 	  NuSelectionBDT::NumuCCTagger _NumuCCTagger_init = {0};
 	  NuSelectionBDT::BDTscores _BDTscores_init = {0};
 
-	  NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {0};
-
     _stkdar_ = _stkdar_init;
 
     _SPID_ = _SPID_init;
@@ -185,8 +179,6 @@ using namespace nsm;
 	  _MajorCosmicTagger_ = _MajorCosmicTagger_init;
 	  _NumuCCTagger_ = _NumuCCTagger_init;
 	  _BDTscores_ = _BDTscores_init;
-
-	  _WCPMTInfo_ = _WCPMTInfo_init;
   }
 
   void NuSelectionBDT::Setstkdar(NuSelectionBDT::stkdar BDT_input){ this->_stkdar_=BDT_input; }
@@ -232,7 +224,7 @@ using namespace nsm;
   void NuSelectionBDT::SetNumuCCTagger(NuSelectionBDT::NumuCCTagger BDT_input){ this->_NumuCCTagger_=BDT_input; }
   void NuSelectionBDT::SetBDTscores(NuSelectionBDT::BDTscores BDT_input){ this->_BDTscores_=BDT_input; }
 
-  void NuSelectionBDT::SetWCPMTInfo(NuSelectionBDT::WCPMTInfo BDT_input){ this->_WCPMTInfo_=BDT_input; }
+
 
   const NuSelectionBDT::stkdar & NuSelectionBDT::Getstkdar() const { return this->_stkdar_; }
 
@@ -277,4 +269,4 @@ using namespace nsm;
   const NuSelectionBDT::NumuCCTagger & NuSelectionBDT::GetNumuCCTagger() const { return this->_NumuCCTagger_; }
   const NuSelectionBDT::BDTscores & NuSelectionBDT::GetBDTscores() const { return this->_BDTscores_; }
 
-  const NuSelectionBDT::WCPMTInfo & NuSelectionBDT::GetWCPMTInfo() const { return this->_WCPMTInfo_; }
+

--- a/ubobj/WcpPort/NuSelectionBDT.h
+++ b/ubobj/WcpPort/NuSelectionBDT.h
@@ -442,24 +442,6 @@ namespace nsm{
   void Setstkdar(stkdar);
   const stkdar & Getstkdar() const;
 
-struct WCPMTInfo{
-	std::vector<double> *WCPMTInfoPePred;
-	std::vector<double> *WCPMTInfoPeMeas;
-	std::vector<double> *WCPMTInfoPeMeasErr;
-	int WCPMTInfoTPCClusterID;
-	int WCPMTInfoFlashID;
-	double WCPMTInfoStrength;
-	int WCPMTInfoEventType;
-	double WCPMTInfoKSDistance;
-	double WCPMTInfoChi2;
-	int WCPMTInfoNDF;
-	double WCPMTInfoClusterLength;
-	int WCPMTInfoNeutrinoType;
-	double WCPMTInfoFlashTime;
-};
-void SetWCPMTInfo(WCPMTInfo);
-const WCPMTInfo & GetWCPMTInfo() const;
-
 
 struct SPID{
     float shw_sp_num_mip_tracks;
@@ -1608,7 +1590,6 @@ struct SPID{
 	MajorCosmicTagger _MajorCosmicTagger_;
 	NumuCCTagger _NumuCCTagger_;
 	BDTscores _BDTscores_;
-	WCPMTInfo _WCPMTInfo_;
   };
 }
 

--- a/ubobj/WcpPort/NuSelectionBDT.h
+++ b/ubobj/WcpPort/NuSelectionBDT.h
@@ -442,6 +442,25 @@ namespace nsm{
   void Setstkdar(stkdar);
   const stkdar & Getstkdar() const;
 
+struct WCPMTInfo{
+	std::vector<double> *WCPMTInfoPePred;
+	std::vector<double> *WCPMTInfoPeMeas;
+	std::vector<double> *WCPMTInfoPeMeasErr;
+	int WCPMTInfoTPCClusterID;
+	int WCPMTInfoFlashID;
+	double WCPMTInfoStrength;
+	int WCPMTInfoEventType;
+	double WCPMTInfoKSDistance;
+	double WCPMTInfoChi2;
+	int WCPMTInfoNDF;
+	double WCPMTInfoClusterLength;
+	int WCPMTInfoNeutrinoType;
+	double WCPMTInfoFlashTime;
+};
+void SetWCPMTInfo(WCPMTInfo);
+const WCPMTInfo & GetWCPMTInfo() const;
+
+
 struct SPID{
     float shw_sp_num_mip_tracks;
     float shw_sp_num_muons;
@@ -1589,6 +1608,7 @@ struct SPID{
 	MajorCosmicTagger _MajorCosmicTagger_;
 	NumuCCTagger _NumuCCTagger_;
 	BDTscores _BDTscores_;
+	WCPMTInfo _WCPMTInfo_;
   };
 }
 

--- a/ubobj/WcpPort/WCPMTInfo.h
+++ b/ubobj/WcpPort/WCPMTInfo.h
@@ -1,0 +1,26 @@
+#ifndef WCPMTInfo_h
+#define WCPMTInfo_h
+
+#include <vector>
+
+namespace nsm{
+
+struct WCPMTInfo{
+	std::vector<double> *WCPMTInfoPePred;
+	std::vector<double> *WCPMTInfoPeMeas;
+	std::vector<double> *WCPMTInfoPeMeasErr;
+	int WCPMTInfoTPCClusterID;
+	int WCPMTInfoFlashID;
+	double WCPMTInfoStrength;
+	int WCPMTInfoEventType;
+	double WCPMTInfoKSDistance;
+	double WCPMTInfoChi2;
+	int WCPMTInfoNDF;
+	double WCPMTInfoClusterLength;
+	int WCPMTInfoNeutrinoType;
+	double WCPMTInfoFlashTime;
+};
+
+}
+
+#endif

--- a/ubobj/WcpPort/classes.h
+++ b/ubobj/WcpPort/classes.h
@@ -13,6 +13,9 @@
 // for BDT input variables
 #include "ubobj/WcpPort/NuSelectionBDT.h"
 
+// for WCPMTInfo
+#include "ubobj/WcpPort/WCPMTInfo.h"
+
 // for kinetic variables
 #include "ubobj/WcpPort/NuSelectionKINE.h"
 

--- a/ubobj/WcpPort/classes_def.xml
+++ b/ubobj/WcpPort/classes_def.xml
@@ -67,9 +67,14 @@
   <class name="nsm::NuSelectionBDT::MajorCosmicTagger"/>
   <class name="nsm::NuSelectionBDT::NumuCCTagger"/>
   <class name="nsm::NuSelectionBDT::BDTscores"/>
+  <class name="nsm::NuSelectionBDT::WCPMTInfo"/>
+  <class name="std::vector<nsm::NuSelectionBDT::WCPMTInfo>"/>
+  <class name="art::Wrapper<std::vector<nsm::NuSelectionBDT::WCPMTInfo>>"/>
   <class name="art::Wrapper<nsm::NuSelectionBDT>"/>
   <class name="std::vector<nsm::NuSelectionBDT>"/>
   <class name="art::Wrapper<std::vector<nsm::NuSelectionBDT>>"/>
+
+
   
   <class name="nsm::NuSelectionKINE"/>
   <class name="nsm::NuSelectionKINE::KineInfo"/>

--- a/ubobj/WcpPort/classes_def.xml
+++ b/ubobj/WcpPort/classes_def.xml
@@ -67,9 +67,9 @@
   <class name="nsm::NuSelectionBDT::MajorCosmicTagger"/>
   <class name="nsm::NuSelectionBDT::NumuCCTagger"/>
   <class name="nsm::NuSelectionBDT::BDTscores"/>
-  <class name="nsm::NuSelectionBDT::WCPMTInfo"/>
-  <class name="std::vector<nsm::NuSelectionBDT::WCPMTInfo>"/>
-  <class name="art::Wrapper<std::vector<nsm::NuSelectionBDT::WCPMTInfo>>"/>
+  <class name="nsm::WCPMTInfo"/>
+  <class name="std::vector<nsm::WCPMTInfo>"/>
+  <class name="art::Wrapper<std::vector<nsm::WCPMTInfo>>"/>
   <class name="art::Wrapper<nsm::NuSelectionBDT>"/>
   <class name="std::vector<nsm::NuSelectionBDT>"/>
   <class name="art::Wrapper<std::vector<nsm::NuSelectionBDT>>"/>


### PR DESCRIPTION
This PR adds a dictionary to save a very small amount of information related to Wire-Cell light flash reconstruction.

This has been tested locally and on the grid.

This accompanies these PRs: https://github.com/uboone/ubreco/pull/29, https://github.com/uboone/ubana/pull/57